### PR TITLE
Add security service definitions to consul

### DIFF
--- a/config/security-proxy-setup.json
+++ b/config/security-proxy-setup.json
@@ -1,0 +1,17 @@
+{
+    "service": {
+        "id": "security-proxy-setup",
+        "name": "security-proxy-setup",
+        "checks": [
+            {
+                "name": "Health Check: security-proxy-setup",
+                "args": [
+                    "/consul/scripts/security-proxy-setup-checker.sh"
+                ],
+                "interval": "1s",
+                "timeout": "1s",
+                "service_id": "security-proxy-setup"
+            }
+        ]
+    }
+}

--- a/config/security-secrets-setup.json
+++ b/config/security-secrets-setup.json
@@ -1,0 +1,17 @@
+{
+    "service": {
+        "id": "security-secrets-setup",
+        "name": "security-secrets-setup",
+        "checks": [
+            {
+                "name": "Health Check: security-secrets-setup",
+                "args": [
+                    "/consul/scripts/security-secrets-setup-checker.sh"
+                ],
+                "interval": "1s",
+                "timeout": "1s",
+                "service_id": "security-secrets-setup"
+            }
+        ]
+    }
+}

--- a/config/security-secretstore-setup.json
+++ b/config/security-secretstore-setup.json
@@ -1,0 +1,17 @@
+{
+    "service": {
+        "id": "security-secretstore-setup",
+        "name": "security-secretstore-setup",
+        "checks": [
+            {
+                "name": "Health Check: security-secretstore-setup",
+                "args": [
+                    "/consul/scripts/security-secretstore-setup-checker.sh"
+                ],
+                "interval": "1s",
+                "timeout": "1s",
+                "service_id": "security-secretstore-setup"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
These service definitions reference script checks from docker-edgex-consul. See https://github.com/edgexfoundry/docker-edgex-consul/pull/6 for those scripts. See also https://github.com/edgexfoundry/developer-scripts/pull/172 for full testing instructions on this change and how to test it with docker-compose from developer-scripts.

See https://github.com/edgexfoundry/edgex-go/issues/1710 for full details on this task.